### PR TITLE
add `--dry-run` option

### DIFF
--- a/cmd/mmv/main.go
+++ b/cmd/mmv/main.go
@@ -48,7 +48,9 @@ Options:
 		fs.PrintDefaults()
 	}
 	var showVersion bool
+	var dryRun bool
 	fs.BoolVar(&showVersion, "version", false, "print version")
+	fs.BoolVar(&dryRun, "dry-run", false, "only show the operation that would have been performed")
 	if err := fs.Parse(args); err != nil {
 		if err == flag.ErrHelp {
 			return exitCodeOK
@@ -64,14 +66,14 @@ Options:
 		fmt.Fprintf(os.Stderr, "usage: %s file ...\n", name)
 		return exitCodeErr
 	}
-	if err := rename(args); err != nil {
+	if err := rename(args, dryRun); err != nil {
 		fmt.Fprintf(os.Stderr, "%s: %s\n", name, err)
 		return exitCodeErr
 	}
 	return exitCodeOK
 }
 
-func rename(args []string) error {
+func rename(args []string, dryRun bool) error {
 	xs := make(map[string]bool, len(args))
 	for _, src := range args {
 		if xs[src] {
@@ -122,5 +124,5 @@ func rename(args []string) error {
 	for i, src := range args {
 		files[src] = got[i]
 	}
-	return mmv.Rename(files)
+	return mmv.Rename(files, dryRun)
 }

--- a/mmv.go
+++ b/mmv.go
@@ -8,10 +8,16 @@ import (
 )
 
 // Rename multiple files.
-func Rename(files map[string]string) error {
+func Rename(files map[string]string, dryRun bool) error {
 	rs, err := buildRenames(files)
 	if err != nil {
 		return err
+	}
+	if dryRun {
+		for _, r := range rs {
+			fmt.Printf("%s => %s\n", r.src, r.dst)
+		}
+		return nil
 	}
 	for i, r := range rs {
 		if err := doRename(r.src, r.dst); err != nil {

--- a/mmv_test.go
+++ b/mmv_test.go
@@ -307,7 +307,7 @@ func TestRename(t *testing.T) {
 			require.NoError(t, setupFiles(tc.contents))
 			rs, _ := buildRenames(clone(tc.files))
 			assert.Equal(t, tc.count, len(rs))
-			err = Rename(tc.files)
+			err = Rename(tc.files, false)
 			if tc.err == "" {
 				assert.NoError(t, err)
 			} else {


### PR DESCRIPTION
Thank you for this awesome tool!

To make it better I add a `--dry-run` option which only shows the operation that would have been performed but not actually renaming anything. Batch renaming is a bit dangerous operation. This option will help users to confirm that the operation is as their expected in some in some situations.