### PR TITLE
fix to pass EDITOR command with args

### DIFF
--- a/cmd/mmv/main.go
+++ b/cmd/mmv/main.go
@@ -100,7 +100,11 @@ func rename(args []string) error {
 		return err
 	}
 	defer tty.Close()
-	cmd := exec.Command(editor, f.Name())
+
+	editorWithArgs := strings.Split(editor, " ")
+	editorWithArgs = append(editorWithArgs, f.Name())
+
+	cmd := exec.Command(editorWithArgs[0], editorWithArgs[1:]...)
 	cmd.Stdin = tty.Input()
 	cmd.Stdout = tty.Output()
 	cmd.Stderr = tty.Output()

--- a/cmd/mmv/main.go
+++ b/cmd/mmv/main.go
@@ -101,7 +101,7 @@ func rename(args []string) error {
 	}
 	defer tty.Close()
 
-	editorWithArgs := strings.Split(editor, " ")
+	editorWithArgs := strings.Fields(editor)
 	editorWithArgs = append(editorWithArgs, f.Name())
 
 	cmd := exec.Command(editorWithArgs[0], editorWithArgs[1:]...)


### PR DESCRIPTION
Hi 😸  I like mmv! Thank you for your creativity.

1. I wanted to set `$EDITOR` = vscode
2. but needed to wait the vscode instance finished
3. and then I set `$EDITOR` with args. this below:

```bash
export EDITOR="code --wait" # same error occurs w/ "vi -e" 

mmv *.svg
mmv: abort renames: exec: "code --wait": executable file not found in $PATH
```

I fixed to pass $EDITOR with args to `exec.Command`.
What do you think of the approach?

Thanks!